### PR TITLE
Reduce runtime memory footprint

### DIFF
--- a/trySwift.xcodeproj/project.pbxproj
+++ b/trySwift.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		048A9BF7A8D3C3DD26D50B41 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9600A9591D00647A023EE414 /* Pods.framework */; };
+		7C30FC061C724C2A00CE5918 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C30FC051C724C2A00CE5918 /* ImageCache.swift */; };
 		FA39E8C71C6AB7640074B6BE /* ScheduleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA39E8C61C6AB7640074B6BE /* ScheduleViewController.swift */; };
 		FA39E8CA1C6AE4080074B6BE /* NavTabButtonCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA39E8C91C6AE4080074B6BE /* NavTabButtonCell.xib */; };
 		FA39E8CD1C6AF8C80074B6BE /* NSLocaleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA39E8CC1C6AF8C80074B6BE /* NSLocaleExtension.swift */; };
@@ -83,6 +84,7 @@
 /* Begin PBXFileReference section */
 		38CAAC53F6ECFE1EAE2B3111 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		45B486A92C7FDE576D71BD2E /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		7C30FC051C724C2A00CE5918 /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		9600A9591D00647A023EE414 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA39E8C61C6AB7640074B6BE /* ScheduleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScheduleViewController.swift; sourceTree = "<group>"; };
 		FA39E8C91C6AE4080074B6BE /* NavTabButtonCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NavTabButtonCell.xib; sourceTree = "<group>"; };
@@ -426,6 +428,7 @@
 			children = (
 				FAFA15BB1C69D31C00FEA4EA /* AppDelegate.swift */,
 				FAFA15BF1C69D31C00FEA4EA /* Main.storyboard */,
+				7C30FC051C724C2A00CE5918 /* ImageCache.swift */,
 				FA39E8C51C6AB7310074B6BE /* ViewControllers */,
 				FA39E8C81C6AE3E50074B6BE /* Views */,
 				FA39E8D51C6AFE200074B6BE /* DataSources */,
@@ -662,6 +665,7 @@
 				FA39E8F11C6C13D70074B6BE /* QASession.swift in Sources */,
 				FA39E8FE1C6C32510074B6BE /* QASessionsViewController.swift in Sources */,
 				FA39E8E81C6B32F80074B6BE /* SessionTableViewCell.swift in Sources */,
+				7C30FC061C724C2A00CE5918 /* ImageCache.swift in Sources */,
 				FA65B58A1C6D8A5200DCAF0B /* OrganizersTableViewController.swift in Sources */,
 				FA39E91D1C6C8D100074B6BE /* WebDisplayViewController.swift in Sources */,
 				FA39E8E51C6B31300074B6BE /* SessionDataSourceDay3.swift in Sources */,

--- a/trySwift/AppDelegate.swift
+++ b/trySwift/AppDelegate.swift
@@ -18,13 +18,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         configureStyling()
 
-        ImageCache.sharedInstance.warmUp (
+        ImageCache.sharedInstance.warmUp {
             (Sponsor.diamondSponsors + Sponsor.goldSponsors + Sponsor.silverSponsors).flatMap{
                 guard let image = UIImage(named: $0.logo) else {
                     return nil
                 }
                 return (key: $0.logo, image: image) }
-        )
+        }
 
         NSTimeZone.setDefaultTimeZone(NSTimeZone(abbreviation: "JST")!)
         return true

--- a/trySwift/AppDelegate.swift
+++ b/trySwift/AppDelegate.swift
@@ -18,6 +18,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         configureStyling()
 
+        ImageCache.sharedInstance.warmUp (
+            (Sponsor.diamondSponsors + Sponsor.goldSponsors + Sponsor.silverSponsors).flatMap{
+                guard let image = UIImage(named: $0.logo) else {
+                    return nil
+                }
+                return (key: $0.logo, image: image) }
+        )
+
         NSTimeZone.setDefaultTimeZone(NSTimeZone(abbreviation: "JST")!)
         return true
     }

--- a/trySwift/ImageCache.swift
+++ b/trySwift/ImageCache.swift
@@ -1,0 +1,75 @@
+//
+//  ImageCache.swift
+//  trySwift
+//
+//  Created by Bhargav Gurlanka on 2/15/16.
+//  Copyright © 2016 NatashaTheRobot. All rights reserved.
+//
+
+import Foundation
+
+/// Implements a simple disk cache
+/// Heavily inspired from https://github.com/onevcat/Kingfisher/blob/master/Sources/ImageCache.swift
+class ImageCache {
+    static let sharedInstance = ImageCache()
+    private(set) var isWarmedUp: Bool
+    private let ioQueue: dispatch_queue_t
+    private let fileManager: NSFileManager
+    private let diskCachePath: String
+    
+    init() {
+        isWarmedUp = false
+ 
+        let cacheName = "com.natashatherobot.trySwift.imgCache"
+        let dstPath = NSSearchPathForDirectoriesInDomains(.CachesDirectory, NSSearchPathDomainMask.UserDomainMask, true).first!
+        
+        diskCachePath = (dstPath as NSString).stringByAppendingPathComponent(cacheName)
+        ioQueue = dispatch_queue_create(cacheName, DISPATCH_QUEUE_SERIAL)
+        fileManager = NSFileManager()
+    }
+    
+    func warmUp(@autoclosure(escaping) imagesClosure: () -> [(key: String, image: UIImage)]) {
+        dispatch_async(ioQueue) { () -> Void in
+            
+            guard !self.fileManager.fileExistsAtPath(self.diskCachePath) else {
+                // already cached
+                self.isWarmedUp = true
+                return
+            }
+            
+            do {
+                try self.fileManager.createDirectoryAtPath(self.diskCachePath, withIntermediateDirectories: true, attributes: nil)
+            } catch _ {}
+            
+            let images = imagesClosure()
+        
+            images.forEach { (key, image) -> () in
+                guard let data: NSData = UIImagePNGRepresentation(image) else {
+                    // couldn't convert to PNG, skipping
+                    return
+                }
+                self.fileManager.createFileAtPath(self.cachePathForKey(key), contents: data, attributes: nil)
+            }
+            
+            self.isWarmedUp = true
+        }
+    }
+    
+    private func cachePathForKey(key: String) -> String {
+        return (diskCachePath as NSString).stringByAppendingPathComponent(key)
+    }
+    
+    func retrieveImage(forKey key: String, completion: (UIImage?) -> (Void)) {
+        func runCompletionOnMainThread(withImage image: UIImage?) {
+            dispatch_async(dispatch_get_main_queue()) {
+                completion(image)
+            }
+        }
+        
+        dispatch_async(ioQueue) {
+            let imageCachePath = self.cachePathForKey(key)
+            let image = UIImage(contentsOfFile: imageCachePath)
+            runCompletionOnMainThread(withImage: image)
+        }
+    }
+}

--- a/trySwift/ImageCache.swift
+++ b/trySwift/ImageCache.swift
@@ -28,7 +28,7 @@ class ImageCache {
         fileManager = NSFileManager()
     }
     
-    func warmUp(@autoclosure(escaping) imagesClosure: () -> [(key: String, image: UIImage)]) {
+    func warmUp(imagesClosure: () -> [(key: String, image: UIImage)]) {
         dispatch_async(ioQueue) { () -> Void in
             
             guard !self.fileManager.fileExistsAtPath(self.diskCachePath) else {

--- a/trySwift/Sponsor.swift
+++ b/trySwift/Sponsor.swift
@@ -25,7 +25,7 @@ struct Sponsor {
     let name: String
     let website: String
     let twitter: String?
-    let logo: UIImage
+    let logo: String
     let level: Level
     let description: String?
 }
@@ -41,7 +41,7 @@ extension Sponsor {
         name: "Realm",
         website: "realm.io",
         twitter: "realm",
-        logo: UIImage(named: "realm")!,
+        logo: "realm",
         level: .Diamond,
         description: nil
     )
@@ -50,7 +50,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社サイバーエージェント" : "CyberAgent, Inc.",
         website: "www.cyberagent.co.jp",
         twitter: "CyberAgent_PR",
-        logo: UIImage(named: "calogo")!,
+        logo: "calogo",
         level: .Diamond,
         description: nil
     )
@@ -60,7 +60,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社メルカリ" : "Mercari, Inc.",
         website: "www.mercari.com",
         twitter: "mercari_jp",
-        logo: UIImage(named: "mercari")!,
+        logo: "mercari",
         level: .Gold,
         description: isJapanese ?
             "メルカリは\"新たな価値を生みだす世界的なマーケットプレイスを創る\"会社です。" :
@@ -71,7 +71,7 @@ extension Sponsor {
         name: isJapanese ? "ケイワイトレード株式会社" : "KY TRADE CO., LTD.",
         website: "www.kytrade.co.jp",
         twitter: nil,
-        logo: UIImage(named: "kyt")!,
+        logo: "kyt",
         level: .Gold,
         description: nil
     )
@@ -80,7 +80,7 @@ extension Sponsor {
         name: isJapanese ? "LINE株式会社" : "LINE Corporation",
         website: "linecorp.com",
         twitter: "LINEjp_official",
-        logo: UIImage(named: "line")!,
+        logo: "line",
         level: .Gold,
         description: isJapanese ?
             "LINE株式会社（本社：日本）は、コミュニケーションアプリ「LINE」および、LINEプラットフォーム上で展開する様々なコンテンツ・サービス（ゲーム、マンガ、音楽、決済など）を運営しています。LINEでは、1対1やグループでの多種多様なスタンプを利用したメッセージサービスや、音声・ビデオ通話によって、世界中のLINEユーザーとのコミュニケーションを無料でお楽しみ頂けます。" :
@@ -93,7 +93,7 @@ extension Sponsor {
         name: isJapanese ? "フェンリル株式会社" : "Fenrir Inc.",
         website: "www.fenrir-inc.com",
         twitter: "fenrir_official",
-        logo: UIImage(named: "fenrir")!,
+        logo: "fenrir",
         level: .Silver,
         description: nil
     )
@@ -102,7 +102,7 @@ extension Sponsor {
         name: "DENSO IT Laboratory, Inc.",
         website: "www.d-itlab.co.jp",
         twitter: "densoitlab",
-        logo: UIImage(named: "denso")!,
+        logo: "denso",
         level: .Silver,
         description: nil
     )
@@ -111,7 +111,7 @@ extension Sponsor {
         name: "VOYAGE GROUP",
         website: "voyagegroup.com",
         twitter: "tech_voyage",
-        logo: UIImage(named: "voyage")!,
+        logo: "voyage",
         level: .Silver,
         description: isJapanese ?
             "株式会社VOYAGE GROUPは、人を軸にした事業開発会社です。\n\nVOYAGE GROUPでは、SOUL（魂：創業時の想い）と8つのCREED（価値観）を経営理念としています。\n\n■SOUL：360°スゴイ\n\n■CREED： 挑戦し続ける。\n\n\t自ら考え、自ら動く。\n\t本質を追い求める。\n\t圧倒的スピード。\n\t仲間と事を成す。\n\tすべてに楽しさを。\n\t真っ直ぐに、誠実に。\n\t\n\t夢と志、そして情熱。" :
@@ -122,7 +122,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社ディー・エヌ・エー" : "DeNa",
         website: "dena.com",
         twitter: "DeNACorp",
-        logo: UIImage(named: "dena")!,
+        logo: "dena",
         level: .Silver,
         description: isJapanese ?
             "1999年に創業した株式会社ディー・エヌ・エー（以下DeNA）はeコマース、ソーシャルゲームを中心に、モバイルサービスに特化した事業展開を行っています。近年ではキュレーションサービスの展開や、自動車やヘルスケアなどリアル巨大産業への進出をしています。http://dena.com/jp/" :
@@ -133,7 +133,7 @@ extension Sponsor {
         name: isJapanese ? "freee株式会社" : "freee K.K.",
         website: "freee.co.jp",
         twitter: "freee_jp",
-        logo: UIImage(named: "freee")!,
+        logo: "freee",
         level: .Silver,
         description: nil
     )
@@ -142,7 +142,7 @@ extension Sponsor {
         name: "Nine Drafts Inc.",
         website: "9drafts.com",
         twitter: "9drafts",
-        logo: UIImage(named: "ninedrafts")!,
+        logo: "ninedrafts",
         level: .Silver,
         description: nil
     )
@@ -151,7 +151,7 @@ extension Sponsor {
         name: "Goodpatch, Inc.",
         website: "goodpatch.com",
         twitter: "GoodpatchTokyo",
-        logo: UIImage(named: "goodpatch")!,
+        logo: "goodpatch",
         level: .Silver,
         description: nil
     )
@@ -160,7 +160,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社はてな" : "Hatena Co., Ltd.",
         website: "hatenacorp.jp",
         twitter: "hatenapr",
-        logo: UIImage(named: "hatena")!,
+        logo: "hatena",
         level: .Silver,
         description: nil
     )
@@ -169,7 +169,7 @@ extension Sponsor {
         name: "GitHub",
         website: "github.com",
         twitter: "github",
-        logo: UIImage(named: "github")!,
+        logo: "github",
         level: .Silver,
         description: nil
     )
@@ -178,7 +178,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社ミクシィ" : "mixi, Inc.",
         website: "mixi.co.jp",
         twitter: "mixi_engineers",
-        logo: UIImage(named: "mixi")!,
+        logo: "mixi",
         level: .Silver,
         description: nil
     )
@@ -187,7 +187,7 @@ extension Sponsor {
         name: "Yahoo! JAPAN",
         website: "yahoo.co.jp",
         twitter: "yahoo",
-        logo: UIImage(named: "yahoo")!,
+        logo: "yahoo",
         level: .Silver,
         description: nil
     )
@@ -196,7 +196,7 @@ extension Sponsor {
         name: isJapanese ? "クックパッド株式会社" : "Cookpad Inc.",
         website: "cookpad.com",
         twitter: "cookpad_pr",
-        logo: UIImage(named: "cookpad")!,
+        logo: "cookpad",
         level: .Silver,
         description: isJapanese ?
             "クックパッドは、毎日の料理を楽しみにを軸に、レシピをはじめとした様々な生活に便利なサービスを提供する世界企業です。日本をはじめ、アメリカ・スペイン・インドネシアにサービスを展開しています。\n\n私たちは、ユーザに素早く価値を提供する必要があります。そのため大きなサービスを小さなサービスに分割するマイクロアーキテクチャや、グローバルのレシピ基盤の開発など、様々なテクノロジーに挑戦しています。" :
@@ -207,7 +207,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社トレタ" : "Toreta, Inc.",
         website: "toreta.in",
         twitter: "TORETA_official",
-        logo: UIImage(named: "toreta")!,
+        logo: "toreta",
         level: .Silver,
         description: nil
     )
@@ -216,7 +216,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社Fablic" : "Fablic, inc.",
         website: "fablic.co.jp",
         twitter: "friljp",
-        logo: UIImage(named: "fablic")!,
+        logo: "fablic",
         level: .Silver,
         description: "フリマアプリフリルを開発しているFablicではユーザー志向の開発をしたいエンジニアを募集しています。"
     )
@@ -225,7 +225,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社リクルートマーケティングパートナーズ" : "Recruit Marketing Partners Co.,Ltd.",
         website: "recruit-mp.co.jp",
         twitter: "recruit_pr",
-        logo: UIImage(named: "recruit-mp")!,
+        logo: "recruit-mp",
         level: .Silver,
         description: nil
     )
@@ -234,7 +234,7 @@ extension Sponsor {
         name: isJapanese ? "クラスメソッド株式会社" : "Classmethod, Inc.",
         website: "classmethod.jp",
         twitter: "classmethod",
-        logo: UIImage(named: "classmethod")!,
+        logo: "classmethod",
         level: .Silver,
         description: nil
     )
@@ -243,7 +243,7 @@ extension Sponsor {
         name: isJapanese ? "フリュー株式会社" : "FURYU Corporation",
         website: "furyu.jp",
         twitter: "furyupr",
-        logo: UIImage(named: "furyu")!,
+        logo: "furyu",
         level: .Silver,
         description: nil
     )
@@ -252,7 +252,7 @@ extension Sponsor {
         name: "Retty, Inc.",
         website: "corp.retty.me",
         twitter: "Retty_jp",
-        logo: UIImage(named: "retty")!,
+        logo: "retty",
         level: .Silver,
         description: nil
     )
@@ -261,7 +261,7 @@ extension Sponsor {
         name: isJapanese ? "Sansan株式会社" : "Sansan, Inc.",
         website: "jp.corp-sansan.com",
         twitter: "sansanjapan",
-        logo: UIImage(named: "sansan")!,
+        logo: "sansan",
         level: .Silver,
         description: isJapanese ?
         "Sansan株式会社は、「ビジネスの出会いを資産に変え、働き方を革新する」をミッションに掲げ、クラウド名刺管理サービス『Sansan』と『Eight』を提供しています。\n世界初の法人向けクラウド名刺管理サービス「Sansan」は、組織全体の働き方を変え、導入企業は2016年1月に4,000社を突破しました。\n個人向けアプリ「Eight」では新たなビジネスSNSの形を提案しり、ユーザー数は100万人を越えています。" :
@@ -272,7 +272,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社Speee" : "Speee, Inc.",
         website: "speee.jp",
         twitter: "speeeinfo",
-        logo: UIImage(named: "speee")!,
+        logo: "speee",
         level: .Silver,
         description: nil
     )
@@ -281,7 +281,7 @@ extension Sponsor {
         name: isJapanese ? "チャットワーク株式会社" : "ChatWork",
         website: "chatwork.com/ja/",
         twitter: "chatwork_ja",
-        logo: UIImage(named: "chatwork")!,
+        logo: "chatwork",
         level: .Silver,
         description: nil
     )
@@ -290,7 +290,7 @@ extension Sponsor {
         name: isJapanese ? "GMOペパボ株式会社" : "GMO Pepabo Inc.",
         website: "pepabo.com",
         twitter: "pepabo",
-        logo: UIImage(named: "pepabo")!,
+        logo: "pepabo",
         level: .Silver,
         description: nil
     )
@@ -299,7 +299,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社Wondershake" : "Wondershake,Inc.",
         website: "locari.jp",
         twitter: "Wondershake",
-        logo: UIImage(named: "wondershake")!,
+        logo: "wondershake",
         level: .Silver,
         description: nil
     )
@@ -308,7 +308,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社ユビレジ" : "Ubiregi Inc.",
         website: "ubiregi.com/ja",
         twitter: "ubiregi",
-        logo: UIImage(named: "ubiregi")!,
+        logo: "ubiregi",
         level: .Silver,
         description: nil
     )
@@ -317,7 +317,7 @@ extension Sponsor {
         name: isJapanese ? "トゥギャッター株式会社" : "Togetter",
         website: "togetter.com",
         twitter: "togetter_jp",
-        logo: UIImage(named: "togetter")!,
+        logo: "togetter",
         level: .Silver,
         description: nil
     )
@@ -326,7 +326,7 @@ extension Sponsor {
         name: "ride",
         website: "ride.com",
         twitter: "ride",
-        logo: UIImage(named: "ride")!,
+        logo: "ride",
         level: .Silver,
         description: nil
     )
@@ -335,7 +335,7 @@ extension Sponsor {
         name: isJapanese ? "日本経済新聞社" : "Nikkei Inc.",
         website: "www.nikkei.com",
         twitter: "nikkei",
-        logo: UIImage(named: "nikkei")!,
+        logo: "nikkei",
         level: .Silver,
         description: isJapanese ?
             "日経電子版は、日本で最大級の有料ニュースサービスです。有料ユーザーの過半数が利用する iPhoneアプリは2015年春に内製化により全面リニューアルし100万ダウンロードを突破しました。続いて紙面をそのまま閲覧できる「紙面ビューアー」もSwiftを使ってこの3月に内製化・リニューアルします。日経電子版ではこれらのアプリを引き続き内製で開発していくためのエンジニアを求めています。詳しい情報は s.nikkei.com/saiyo を御覧ください。" :
@@ -346,7 +346,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社PR TIMES" : "PR TIMES, Inc.",
         website: "prtimes.co.jp",
         twitter: "PRTIMES_JP",
-        logo: UIImage(named: "prtimes")!,
+        logo: "prtimes",
         level: .Silver,
         description: isJapanese ?
             "「企業と生活者をつなぎ、世の中にいいものを広める」それがPR TIMESです。プレスリリース配信サービス「PR TIMES」はプレスリリースにテクノロジーを加えることで、より多彩な表現を実現し、多くの優良なプレスリリースが集まっています。プレスリリース配信シェアとサイト月間PV数は、共に国内No.1です。また、昨年お問い合わせフォームなどが直感的に作成できるカスタマーサポートツール「Tayori」も立ち上げ、好評を頂いています。" :
@@ -357,7 +357,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社オハコ" : "OHAKO, Inc.",
         website: "ohako-inc.jp",
         twitter: "OhakoJP",
-        logo: UIImage(named: "ohako")!,
+        logo: "ohako",
         level: .Silver,
         description: nil
     )
@@ -366,7 +366,7 @@ extension Sponsor {
         name: isJapanese ? "株式会社ookami" : "ookami, inc",
         website: "playerapp.tokyo",
         twitter: "Player_twi",
-        logo: UIImage(named: "ookami")!,
+        logo: "ookami",
         level: .Silver,
         description: nil
     )
@@ -375,7 +375,7 @@ extension Sponsor {
         name: "Perfect",
         website: "perfect.org",
         twitter: "perfectlysoft",
-        logo: UIImage(named: "perfect")!,
+        logo: "perfect",
         level: .Silver,
         description: isJapanese ? nil : "Server-Side Swift is here! - developed by PerfectlySoft, Perfect is a framework for developing web and other REST services in the Swift programming language. Its primary focus is on facilitating mobile apps which require backend server connections, allowing you to use Swift for both user-side and server-side development. It’s the perfect backbone for cloud and mobile technologies, web development and cross-platform development. Developers can now write less code and work in the powerful, modern and elegant Swift language for all of their needs."
     )
@@ -384,7 +384,7 @@ extension Sponsor {
         name: "Instagram",
         website: "instagram.com",
         twitter: "instagram",
-        logo: UIImage(named: "Instagram")!,
+        logo: "Instagram",
         level: .Silver,
         description: nil
     )
@@ -393,7 +393,7 @@ extension Sponsor {
         name: isJapanese ? "からくり株式会社" : "Caraquri Inc.",
         website: "caraquri.com",
         twitter: "caraquri",
-        logo: UIImage(named: "caraquri")!,
+        logo: "caraquri",
         level: .Silver,
         description: isJapanese ?
             "iOS/Androidアプリ開発の会社です。クライアントと消費者とのコミュニケーションチャンネルとしてアプリを開発することが多く、動画視聴アプリ、小売向け会員アプリ、販促向けクーポンアプリ、ポータルサイトのニュースアプリ、電子書籍アプリなどを主に手がけています。" :

--- a/trySwift/SponsorTableViewCell.swift
+++ b/trySwift/SponsorTableViewCell.swift
@@ -21,7 +21,14 @@ class SponsorTableViewCell: UITableViewCell {
     }
     
     func configure(withSponsor sponsor: Sponsor) {
-        sponsorImageView.image = sponsor.logo
+        
+        ImageCache.sharedInstance.retrieveImage(forKey: sponsor.logo) { maybeImage in
+            guard let image = maybeImage else {
+                return
+            }
+            self.sponsorImageView.image = image
+        }
+
         sponsorNameLabel.text = sponsor.name
         websiteLabel.text = sponsor.website
     }


### PR DESCRIPTION
SponsorsViewController heavily uses `UIImage(named: )` which caches the images into memory causing memory footprint to go well beyond 150MB.

Added `ImageCache` class to read the images from asset catalog, write them to Cache folder. These cached images can then be loaded on demand using `UIImage(contentsOfFile: )`