### PR TITLE
Fix content inset at top of scrollview.

### DIFF
--- a/trySwift/Base.lproj/Main.storyboard
+++ b/trySwift/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Xe8-8h-xaI">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Xe8-8h-xaI">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
@@ -55,14 +55,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RPm-KG-Btr">
-                                <rect key="frame" x="0.0" y="104" width="600" height="447"/>
+                                <rect key="frame" x="0.0" y="108" width="600" height="443"/>
                                 <inset key="scrollIndicatorInsets" minX="0.0" minY="10" maxX="0.0" maxY="0.0"/>
                             </scrollView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="RPm-KG-Btr" secondAttribute="trailing" id="2JL-pe-QDA"/>
-                            <constraint firstItem="RPm-KG-Btr" firstAttribute="top" secondItem="bcc-5u-M0d" secondAttribute="bottom" constant="40" id="8Kf-H1-MHx"/>
+                            <constraint firstItem="RPm-KG-Btr" firstAttribute="top" secondItem="bcc-5u-M0d" secondAttribute="bottom" constant="44" id="8Kf-H1-MHx"/>
                             <constraint firstItem="RPm-KG-Btr" firstAttribute="leading" secondItem="VW6-6Q-noy" secondAttribute="leading" id="bo3-5R-xw2"/>
                             <constraint firstItem="yee-Gn-CeI" firstAttribute="top" secondItem="RPm-KG-Btr" secondAttribute="bottom" id="fuz-pw-IWT"/>
                         </constraints>
@@ -275,14 +275,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98Y-7i-ZD0">
-                                <rect key="frame" x="0.0" y="104" width="600" height="447"/>
+                                <rect key="frame" x="0.0" y="108" width="600" height="443"/>
                                 <inset key="scrollIndicatorInsets" minX="0.0" minY="10" maxX="0.0" maxY="0.0"/>
                             </scrollView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="98Y-7i-ZD0" firstAttribute="leading" secondItem="CDc-Er-RQB" secondAttribute="leading" id="H4N-Sy-Ije"/>
-                            <constraint firstItem="98Y-7i-ZD0" firstAttribute="top" secondItem="eON-q3-RA2" secondAttribute="bottom" constant="40" id="Hg8-fw-HDq"/>
+                            <constraint firstItem="98Y-7i-ZD0" firstAttribute="top" secondItem="eON-q3-RA2" secondAttribute="bottom" constant="44" id="Hg8-fw-HDq"/>
                             <constraint firstItem="cp8-0P-D8j" firstAttribute="top" secondItem="98Y-7i-ZD0" secondAttribute="bottom" id="ket-2O-Eqk"/>
                             <constraint firstAttribute="trailing" secondItem="98Y-7i-ZD0" secondAttribute="trailing" id="w6V-iH-Fge"/>
                         </constraints>

--- a/trySwift/SessionDetailsViewController.swift
+++ b/trySwift/SessionDetailsViewController.swift
@@ -21,7 +21,7 @@ class SessionDetailsViewController: UITableViewController {
         super.viewDidLoad()
 
         title = session.description
-        
+
         tableView.registerNib(UINib(nibName: String(SessionHeaderTableViewCell), bundle: nil), forCellReuseIdentifier: String(SessionHeaderTableViewCell))
         tableView.registerNib(UINib(nibName: String(SpeakerTableViewCell), bundle: nil), forCellReuseIdentifier: String(SpeakerTableViewCell))
         tableView.registerNib(UINib(nibName: String(TextTableViewCell), bundle: nil), forCellReuseIdentifier: String(TextTableViewCell))
@@ -29,7 +29,6 @@ class SessionDetailsViewController: UITableViewController {
 
         tableView.estimatedRowHeight = 83
         tableView.rowHeight = UITableViewAutomaticDimension
-        tableView.contentInset = UIEdgeInsetsMake(20, 0, 0, 0)
         tableView.separatorStyle = .None
     }
 

--- a/trySwift/SpeakerDetailViewController.swift
+++ b/trySwift/SpeakerDetailViewController.swift
@@ -27,7 +27,6 @@ class SpeakerDetailViewController: UITableViewController {
         
         tableView.estimatedRowHeight = 83
         tableView.rowHeight = UITableViewAutomaticDimension
-        tableView.contentInset = UIEdgeInsetsMake(20, 0, 0, 0)
         tableView.separatorStyle = .None
     }
 


### PR DESCRIPTION
Default scroll point is slightly misaligned.
L: before / R: after
<img width="1220" alt="2016-02-21 14 48 12" src="https://cloud.githubusercontent.com/assets/934291/13201257/6ad56a2a-d8ac-11e5-8432-69c6e586ce32.png">


I modified constraints from 40 to 44 at top of UIScrollView on `ScheduleViewController` and `QASessionsViewController`. (aebf124)
<img width="899" alt="2016-02-21 14 49 38" src="https://cloud.githubusercontent.com/assets/934291/13201279/13a07e6a-d8ad-11e5-8d06-a2d219a08abc.png">

And, since it does not work, I removed line of setting a contentInset. (069877b)