### PR TITLE
Fixed cell selected state problem

### DIFF
--- a/trySwift/OrganizersTableViewController.swift
+++ b/trySwift/OrganizersTableViewController.swift
@@ -22,14 +22,6 @@ class OrganizersTableViewController: UITableViewController {
         tableView.rowHeight = UITableViewAutomaticDimension
     }
 
-    override func viewWillAppear(animated: Bool) {
-        super.viewWillAppear(animated)
-
-        if let indexPath = tableView.indexPathForSelectedRow {
-            tableView.deselectRowAtIndexPath(indexPath, animated: true)
-        }
-    }
-
     // MARK: - Table view data source
 
     override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
@@ -81,6 +73,8 @@ class OrganizersTableViewController: UITableViewController {
             webViewController.displayTitle = "@\(username)"
             navigationController?.pushViewController(webViewController, animated: true)
         }
+        
+        tableView.deselectRowAtIndexPath(indexPath, animated: true)
     }
 
 }


### PR DESCRIPTION
Problem: When the system dialog which asks to permit openUrl is shown or when it opens another app, the cell's selected state is not changed. (`viewWillAppear:` is called only when it's back from webViewController.)